### PR TITLE
Fixed the 'Cannot read property bool of undefined' problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   },
   "homepage": "https://github.com/fuyaode/react-native-app-intro#readme",
   "dependencies": {
-    "assign-deep": "^0.4.5",
-    "react-native-swiper": "git+https://github.com/FuYaoDe/react-native-swiper.git"
+    "assign-deep": "^0.4.6",
+    "prop-types": "^15.6.0",
+    "react-native-swiper": "^1.5.13",
   }
 }


### PR DESCRIPTION
Fixed the "Cannot read property 'bool' of undefined" problem due to old prop-types usage and react-native-swiper relations.
Updated the **assign-deep** package from 0.4.5 to 0.4.6