### PR TITLE
Fixed 'Cannot read property bool of undefined' problem due to old pro…

### DIFF
--- a/AppIntro.js
+++ b/AppIntro.js
@@ -1,5 +1,6 @@
 import assign from 'assign-deep';
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import {
   StatusBar,
   StyleSheet,

--- a/Example/AppIntro.js
+++ b/Example/AppIntro.js
@@ -1,5 +1,6 @@
 import assign from 'assign-deep';
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import {
   StatusBar,
   StyleSheet,

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   },
   "homepage": "https://github.com/fuyaode/react-native-app-intro#readme",
   "dependencies": {
-    "assign-deep": "^0.4.5",
-    "react-native-swiper": "git+https://github.com/FuYaoDe/react-native-swiper.git"
+    "assign-deep": "^0.4.6",
+    "prop-types": "^15.6.0",
+    "react-native-swiper": "^1.5.13",
   }
 }


### PR DESCRIPTION
Fixed 'Cannot read property bool of undefined' problem due to old prop-types usage and react-native-swiper relations.

Updated the assign-deep package from 0.4.5 to 0.4.6